### PR TITLE
Fix: Update markdownlint action to resolve GitHub Actions error

### DIFF
--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check Markdown
-        uses: DavidAnson/markdownlint-action@v1
+        uses: DavidAnson/markdownlint-cli2-action@v20
         with:
           config: .markdownlint.json
 


### PR DESCRIPTION
The previous action DavidAnson/markdownlint-action@v1 was deprecated and causing errors in the documentation-check workflow.

This commit updates the workflow to use the recommended action DavidAnson/markdownlint-cli2-action@v20.