### PR TITLE
fix: include CLAUDE.md in markdown linting

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -11,6 +11,5 @@
   },
   "MD041": {
     "level": 1  // 最初の見出しのレベル
-  },
-  "ignores": ["CLAUDE.md"]  // CLAUDE.mdを対象外にする
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ You are an experienced engineer with the following strengths:
 5. Only then proceed with standard git commit (never --no-verify)
 
 **If user requests process violations:**
+
 - Politely refuse and explain proper workflow
 - Suggest correct alternative approach
 - Never compromise on quality standards

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check:docs": "bash scripts/check-docs.sh",
     "check:docs:size": "find docs -name '*.md' -exec sh -c 'size=$(wc -c < \\\"$1\\\"); [ $size -gt 10000 ] && echo \\\"$1: $size bytes (exceeds 10KB)\\\"' _ {} \\\\;",
-    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#docs/standards/bulletproof-react' '#.yarn' '#docs/standards/naming-cheatsheet' '#CLAUDE.md'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#docs/standards/bulletproof-react' '#.yarn' '#docs/standards/naming-cheatsheet'",
     "format:md": "prettier --write \"**/*.md\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Remove CLAUDE.md from markdown lint exclusions to ensure consistency
- Fix markdown lint error in CLAUDE.md
- Align local and CI markdown check configurations

## Changes
- Remove CLAUDE.md exclusion from `lint:md` script in package.json
- Remove CLAUDE.md exclusion from .markdownlint.jsonc
- Fix MD032 error in CLAUDE.md (add blank line before list)
- Ensure GitHub Actions uses the same lint configuration as local checks

## Test plan
- [x] Run `yarn check:docs` locally - passes
- [x] Run `yarn lint:md` locally - passes
- [ ] GitHub Actions Documentation Check workflow should pass

🤖 Generated with [Claude Code](https://claude.ai/code)