### PR TITLE
feat: PBI-1-12 receipt-transaction matching logic

### DIFF
--- a/__tests__/receipt-matcher.test.ts
+++ b/__tests__/receipt-matcher.test.ts
@@ -1,0 +1,151 @@
+import type { FreeeTransaction } from '@/lib/freee-transactions'
+import {
+  ReceiptTransactionMatcher,
+  defaultReceiptMatcher,
+  findReceiptMatches,
+} from '@/lib/receipt-matcher'
+import type { ParsedReceiptData } from '@/lib/text-parser'
+import { describe, expect, it } from 'vitest'
+
+describe('ReceiptTransactionMatcher', () => {
+  const mockReceipt: ParsedReceiptData = {
+    amount: 1000,
+    date: new Date('2024-01-15'),
+    vendor: 'Test Store',
+    rawText: 'Test receipt text',
+  }
+
+  const mockTransactions: FreeeTransaction[] = [
+    {
+      id: 1,
+      date: '2024-01-15',
+      amount: 1000,
+      description: 'Store purchase',
+      status: 'pending',
+      receipt_ids: [],
+    },
+    {
+      id: 2,
+      date: '2024-01-14',
+      amount: 1050,
+      description: 'Similar amount',
+      status: 'pending',
+      receipt_ids: [],
+    },
+    {
+      id: 3,
+      date: '2024-01-20',
+      amount: 2000,
+      description: 'Different amount',
+      status: 'pending',
+      receipt_ids: [],
+    },
+  ]
+
+  describe('findMatches', () => {
+    it('完全一致の場合、exactマッチを返す', () => {
+      const matcher = new ReceiptTransactionMatcher({
+        amountTolerance: 0.05,
+        dateTolerance: 3,
+        minimumScore: 0.1,
+      })
+      const matches = matcher.findMatches(mockReceipt, mockTransactions)
+
+      expect(matches).toHaveLength(3)
+      expect(matches[0].matchType).toBe('exact')
+      expect(matches[0].transaction.id).toBe(1)
+      expect(matches[0].score).toBeCloseTo(1.0, 2)
+    })
+
+    it('金額・日付が未設定の場合、空配列を返す', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const invalidReceipt = { rawText: 'no amount or date' }
+      const matches = matcher.findMatches(invalidReceipt, mockTransactions)
+
+      expect(matches).toHaveLength(0)
+    })
+
+    it('スコア順に結果をソートして返す', () => {
+      const matcher = new ReceiptTransactionMatcher({
+        amountTolerance: 0.05,
+        dateTolerance: 3,
+        minimumScore: 0.1,
+      })
+      const matches = matcher.findMatches(mockReceipt, mockTransactions)
+
+      expect(matches).toHaveLength(3)
+      for (let i = 0; i < matches.length - 1; i++) {
+        expect(matches[i].score).toBeGreaterThanOrEqual(matches[i + 1].score)
+      }
+    })
+  })
+
+  describe('calculateScore', () => {
+    it('完全一致の場合、スコア1.0を返す', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const score = matcher.calculateScore(mockReceipt, mockTransactions[0])
+
+      expect(score).toBeCloseTo(1.0, 2)
+    })
+
+    it('金額が近似の場合、高いスコアを返す', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const score = matcher.calculateScore(mockReceipt, mockTransactions[1])
+
+      expect(score).toBeGreaterThan(0.7)
+      expect(score).toBeLessThan(1.0)
+    })
+
+    it('金額が大きく異なる場合、低いスコアを返す', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const score = matcher.calculateScore(mockReceipt, mockTransactions[2])
+
+      expect(score).toBeLessThan(0.7)
+    })
+  })
+
+  describe('matchType判定', () => {
+    it('高スコア(≥0.9)でexactを判定', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const matches = matcher.findMatches(mockReceipt, [mockTransactions[0]])
+
+      expect(matches[0].matchType).toBe('exact')
+    })
+
+    it('中スコア(≥0.7)でapproximateを判定', () => {
+      const matcher = new ReceiptTransactionMatcher()
+      const matches = matcher.findMatches(mockReceipt, [mockTransactions[1]])
+
+      expect(matches[0].matchType).toBe('approximate')
+    })
+
+    it('低スコア(<0.7)でpartialを判定', () => {
+      const matcher = new ReceiptTransactionMatcher({
+        amountTolerance: 0.05,
+        dateTolerance: 3,
+        minimumScore: 0.1,
+      })
+      const matches = matcher.findMatches(mockReceipt, [mockTransactions[2]])
+
+      expect(matches).toHaveLength(1)
+      expect(matches[0].matchType).toBe('partial')
+    })
+  })
+
+  describe('findReceiptMatches関数', () => {
+    it('デフォルトマッチャーで正常動作', () => {
+      const matches = findReceiptMatches(mockReceipt, mockTransactions)
+      expect(matches.length).toBeGreaterThan(0)
+    })
+
+    it('カスタム基準で正常動作', () => {
+      const customCriteria = {
+        amountTolerance: 0.1,
+        dateTolerance: 5,
+        minimumScore: 0.5,
+      }
+      const matches = findReceiptMatches(mockReceipt, mockTransactions, customCriteria)
+      expect(matches.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/src/lib/receipt-matcher.ts
+++ b/src/lib/receipt-matcher.ts
@@ -1,0 +1,157 @@
+/** レシート・取引マッチングロジック */
+
+import type { FreeeTransaction } from '@/lib/freee-transactions'
+import type { ParsedReceiptData } from '@/lib/text-parser'
+
+/**
+ * マッチング結果
+ */
+export interface MatchResult {
+  transaction: FreeeTransaction
+  receipt: ParsedReceiptData
+  score: number
+  matchType: 'exact' | 'approximate' | 'partial'
+}
+
+/**
+ * マッチング基準設定
+ */
+export interface MatchingCriteria {
+  amountTolerance: number
+  dateTolerance: number
+  minimumScore: number
+}
+
+/**
+ * レシート・取引マッチャーインターフェース
+ */
+export interface ReceiptMatcher {
+  findMatches(receipt: ParsedReceiptData, transactions: FreeeTransaction[]): MatchResult[]
+  calculateScore(receipt: ParsedReceiptData, transaction: FreeeTransaction): number
+}
+
+/**
+ * デフォルトマッチング基準
+ */
+const DEFAULT_CRITERIA: MatchingCriteria = {
+  amountTolerance: 0.05, // 5%許容
+  dateTolerance: 3, // ±3日
+  minimumScore: 0.3,
+}
+
+/**
+ * レシート・取引マッチング実装クラス
+ */
+export class ReceiptTransactionMatcher implements ReceiptMatcher {
+  private criteria: MatchingCriteria
+
+  constructor(criteria: MatchingCriteria = DEFAULT_CRITERIA) {
+    this.criteria = criteria
+  }
+
+  /**
+   * レシートに対する取引候補を検索
+   */
+  findMatches(receipt: ParsedReceiptData, transactions: FreeeTransaction[]): MatchResult[] {
+    if (!receipt.amount || !receipt.date) {
+      return []
+    }
+
+    const results: MatchResult[] = []
+
+    for (const transaction of transactions) {
+      const score = this.calculateScore(receipt, transaction)
+      if (score >= this.criteria.minimumScore) {
+        const matchType = this.determineMatchType(receipt, transaction, score)
+        results.push({
+          transaction,
+          receipt,
+          score,
+          matchType,
+        })
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score)
+  }
+
+  /**
+   * レシートと取引の類似度スコア計算
+   */
+  calculateScore(receipt: ParsedReceiptData, transaction: FreeeTransaction): number {
+    let totalScore = 0
+    let factors = 0
+
+    // 金額マッチング (重要度: 0.6)
+    if (receipt.amount && transaction.amount) {
+      const amountScore = this.calculateAmountScore(receipt.amount, transaction.amount)
+      totalScore += amountScore * 0.6
+      factors += 0.6
+    }
+
+    // 日付マッチング (重要度: 0.4)
+    if (receipt.date) {
+      const dateScore = this.calculateDateScore(receipt.date, new Date(transaction.date))
+      totalScore += dateScore * 0.4
+      factors += 0.4
+    }
+
+    return factors > 0 ? totalScore / factors : 0
+  }
+
+  private calculateAmountScore(receiptAmount: number, transactionAmount: number): number {
+    if (receiptAmount === transactionAmount) return 1.0
+
+    const difference = Math.abs(receiptAmount - transactionAmount)
+    const tolerance = transactionAmount * this.criteria.amountTolerance
+
+    if (difference <= tolerance) {
+      return 1.0 - (difference / tolerance) * 0.2 // 許容範囲内で0.8-1.0
+    }
+
+    // 許容範囲外は指数的減衰
+    const ratio = difference / transactionAmount
+    return Math.max(0, 1.0 - (ratio * 2) ** 2)
+  }
+
+  private calculateDateScore(receiptDate: Date, transactionDate: Date): number {
+    const dayDiff = Math.abs(
+      Math.floor((receiptDate.getTime() - transactionDate.getTime()) / (1000 * 60 * 60 * 24))
+    )
+
+    if (dayDiff === 0) return 1.0
+    if (dayDiff <= this.criteria.dateTolerance) {
+      return 1.0 - (dayDiff / this.criteria.dateTolerance) * 0.3 // 許容範囲内で0.7-1.0
+    }
+
+    // 許容範囲外は線形減衰
+    return Math.max(0, 0.7 - (dayDiff - this.criteria.dateTolerance) * 0.1)
+  }
+
+  private determineMatchType(
+    receipt: ParsedReceiptData,
+    transaction: FreeeTransaction,
+    score: number
+  ): 'exact' | 'approximate' | 'partial' {
+    if (score >= 0.9) return 'exact'
+    if (score >= 0.7) return 'approximate'
+    return 'partial'
+  }
+}
+
+/**
+ * デフォルトマッチャーインスタンス
+ */
+export const defaultReceiptMatcher = new ReceiptTransactionMatcher()
+
+/**
+ * レシートマッチング関数（簡単アクセス用）
+ */
+export function findReceiptMatches(
+  receipt: ParsedReceiptData,
+  transactions: FreeeTransaction[],
+  criteria?: MatchingCriteria
+): MatchResult[] {
+  const matcher = criteria ? new ReceiptTransactionMatcher(criteria) : defaultReceiptMatcher
+  return matcher.findMatches(receipt, transactions)
+}


### PR DESCRIPTION
## Summary
- OCRレシートデータとfreee取引データの金額・日付ベースマッチング機能を実装
- 信頼度スコア計算システム（金額0.6・日付0.4重み）を追加
- 複数候補対応・スコア順ランキング機能を実装

## Implementation Details
- **File**: `src/lib/receipt-matcher.ts` (157行)
- **Test**: `__tests__/receipt-matcher.test.ts` (11テストケース全パス)
- **Features**:
  - 金額完全一致・近似一致（許容誤差5%設定可能）
  - 日付範囲マッチング（±3日設定可能）
  - 3段階マッチタイプ判定（exact/approximate/partial）
  - 設定可能なマッチング基準

## Quality Assurance
- ✅ TypeScript: 0エラー
- ✅ Lint: 問題なし
- ✅ Test: 40/40パス（マッチングテスト11/11パス）
- ✅ PBI受け入れ基準: 100%達成

🤖 Generated with [Claude Code](https://claude.ai/code)